### PR TITLE
terraform: provision gke cluster

### DIFF
--- a/config/terraform/.gitignore
+++ b/config/terraform/.gitignore
@@ -1,0 +1,8 @@
+# Terraform files
+.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+
+# Sensitive files
+*.auto.tfvars

--- a/config/terraform/gke.tf
+++ b/config/terraform/gke.tf
@@ -64,7 +64,6 @@ resource "google_container_node_pool" "primary_nodes" {
       env = var.project_id
     }
 
-    # preemptible  = true
     machine_type = var.machine_type
     tags         = ["gke-node", "${var.project_id}-gke"]
     metadata = {

--- a/config/terraform/gke.tf
+++ b/config/terraform/gke.tf
@@ -18,6 +18,13 @@ resource "google_container_cluster" "primary" {
   network    = google_compute_network.vpc.name
   subnetwork = google_compute_subnetwork.subnet.name
 
+  # Prometheus monitoring takes a lot of cpu
+  monitoring_config {
+    managed_prometheus {
+      enabled = false # Explicitly disable managed prometheus
+    }
+  }
+
   private_cluster_config {
     enable_private_nodes    = true
     enable_private_endpoint = false

--- a/config/terraform/gke.tf
+++ b/config/terraform/gke.tf
@@ -1,0 +1,50 @@
+# GKE cluster
+data "google_container_engine_versions" "gke_version" {
+  location = "${var.region}-b"
+  version_prefix = "1.27."
+}
+
+# Create a minimal GKE cluster
+resource "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = "${var.region}-b"
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
+
+  deletion_protection = false
+}
+
+# Separately Managed Node Pool
+resource "google_container_node_pool" "primary_nodes" {
+  name       = google_container_cluster.primary.name
+  location   = "${var.region}-b"
+  cluster    = google_container_cluster.primary.name
+  
+  version = data.google_container_engine_versions.gke_version.release_channel_default_version["STABLE"]
+  node_count = var.node_count
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels = {
+      env = var.project_id
+    }
+
+    # preemptible  = true
+    machine_type = var.machine_type
+    tags         = ["gke-node", "${var.project_id}-gke"]
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}

--- a/config/terraform/gke.tf
+++ b/config/terraform/gke.tf
@@ -1,6 +1,6 @@
 # GKE cluster
 data "google_container_engine_versions" "gke_version" {
-  location = "${var.region}-b"
+  location       = "${var.region}-b"
   version_prefix = "1.27."
 }
 
@@ -23,11 +23,11 @@ resource "google_container_cluster" "primary" {
 
 # Separately Managed Node Pool
 resource "google_container_node_pool" "primary_nodes" {
-  name       = google_container_cluster.primary.name
-  location   = "${var.region}-b"
-  cluster    = google_container_cluster.primary.name
+  name     = google_container_cluster.primary.name
+  location = "${var.region}-b"
+  cluster  = google_container_cluster.primary.name
   
-  version = data.google_container_engine_versions.gke_version.release_channel_default_version["STABLE"]
+  version    = data.google_container_engine_versions.gke_version.release_channel_default_version["STABLE"]
   node_count = var.node_count
 
   node_config {

--- a/config/terraform/main.tf
+++ b/config/terraform/main.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/config/terraform/terraform.tfvars
+++ b/config/terraform/terraform.tfvars
@@ -1,6 +1,6 @@
-region        = "us-east4"
+region = "us-east1" # us-east1 qualifies for free tier
 
 # GKE config
-cluster_name  = "prod-gke"
-node_count    = 1
-machine_type  = "e2-micro"
+cluster_name = "prod-gke"
+node_count   = 1
+machine_type = "e2-micro"

--- a/config/terraform/terraform.tfvars
+++ b/config/terraform/terraform.tfvars
@@ -1,6 +1,6 @@
-region = "us-east1" # us-east1 qualifies for free tier
+region = "us-east1"
 
 # GKE config
 cluster_name = "prod-gke"
 node_count   = 1
-machine_type = "e2-micro"
+machine_type = "e2-medium"

--- a/config/terraform/terraform.tfvars
+++ b/config/terraform/terraform.tfvars
@@ -1,0 +1,6 @@
+region        = "us-east4"
+
+# GKE config
+cluster_name  = "prod-gke"
+node_count    = 1
+machine_type  = "e2-micro"

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -22,5 +22,10 @@ variable "node_count" {
 variable "machine_type" {
   description = "Machine type for the nodes"
   type        = string
-  default     = "e2-micro"  # Smallest general-purpose machine type
-} 
+  default     = "e2-micro" # Smallest general-purpose machine type
+}
+
+variable "k8s_master_allowed_ip" {
+  description = "IP address allowed to access the k8s control plane"
+  type        = string
+}

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -16,13 +16,13 @@ variable "cluster_name" {
 variable "node_count" {
   description = "Number of nodes in the cluster"
   type        = number
-  default     = 2
+  default     = 1
 }
 
 variable "machine_type" {
   description = "Machine type for the nodes"
   type        = string
-  default     = "e2-micro" # Smallest general-purpose machine type
+  default     = "e2-medium"
 }
 
 variable "k8s_master_allowed_ip" {

--- a/config/terraform/variables.tf
+++ b/config/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "The ID of the GCP project"
+  type        = string
+}
+
+variable "region" {
+  description = "The region where resources will be created"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the cluster"
+  type        = number
+  default     = 2
+}
+
+variable "machine_type" {
+  description = "Machine type for the nodes"
+  type        = string
+  default     = "e2-micro"  # Smallest general-purpose machine type
+} 

--- a/config/terraform/vpc.tf
+++ b/config/terraform/vpc.tf
@@ -1,0 +1,13 @@
+# VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${var.project_id}-vpc"
+  auto_create_subnetworks = "false"
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.project_id}-subnet"
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = "10.10.0.0/24"
+}


### PR DESCRIPTION
Using terraform, provision a small GKE cluster with a VPC.

Minorly interesting config points: 
- `cluster.monitoring_config.managed_prometheus` - I set this to false. When looking at the utilization of the cluster, the managed prometheus ate up a ton of resources. 
- `cluster.master_authorized_networks_config` - this is set to my IP address for now. It means that only this IP address can access the control plane, even though `enable_private_endpoint = false`. 