### PR TITLE
fix ssl certs

### DIFF
--- a/config/helm/templates/managed-cert.yaml
+++ b/config/helm/templates/managed-cert.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.namespace "prod" }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{.Values.namespace}}-cert
+  namespace: {{.Values.namespace}}
+spec:
+  domains:
+    - {{.Values.domainName}}
+    - api.{{.Values.domainName}}
+{{- end }} 

--- a/config/helm/values-prod.yaml
+++ b/config/helm/values-prod.yaml
@@ -2,7 +2,7 @@ namespace: prod
 imagePullPolicy: Always
 frontendServiceType: ClusterIP
 backendServiceType: ClusterIP
-apiUrl: http://api.whatiftherewasatrain.com
+apiUrl: https://api.whatiftherewasatrain.com
 rustEnv: production
 rustBackTrace: 0
 apiImageName: dispatch:latest

--- a/config/terraform/gke.tf
+++ b/config/terraform/gke.tf
@@ -162,14 +162,6 @@ resource "google_dns_record_set" "api" {
   rrdatas      = [google_compute_global_address.default.address]
 }
 
-# SSL Certificate
-resource "google_compute_managed_ssl_certificate" "default" {
-  name = "${var.project_id}-cert"
-  managed {
-    domains = [var.domain_name]
-  }
-}
-
 # Output the static IP address
 output "static_ip" {
   value = google_compute_global_address.default.address


### PR DESCRIPTION
Since k8s is managing our load balancers through an ingress controller, our SSL cert also needs to be there as well, as the SSL cert is for the load balancer. Previously it was attempting to attach to the static IP address but that was invalid - it needs to point at a load balancer according to google.
